### PR TITLE
Updating regex pattern for removing import statements

### DIFF
--- a/lib/parserEtherscan.js
+++ b/lib/parserEtherscan.js
@@ -137,7 +137,7 @@ class EtherscanParser {
             // match whitespace before import
             // and characters after import up to ;
             // replace all in file and match across multiple lines
-            const removedImports = removedPragmaSolidity.replace(/(\s)(import.*;)/gm, '$1/* $2 */');
+            const removedImports = removedPragmaSolidity.replace(/^\s*?(import.*?;)/gms, '/* $1 */');
             // Rename SPDX-License-Identifier to SPDX--License-Identifier so the merged file will compile
             const removedSPDX = removedImports.replace(/SPDX-/, 'SPDX--');
             solidityCode += removedSPDX;

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "sol2uml": "lib/sol2uml.js"
       },
       "devDependencies": {
-        "@openzeppelin/contracts": "4.8.0",
+        "@openzeppelin/contracts": "^4.8.2",
         "@types/diff-match-patch": "^1.0.32",
         "@types/jest": "^29.4.0",
         "@types/klaw": "^3.0.3",
@@ -1732,9 +1732,9 @@
       }
     },
     "node_modules/@openzeppelin/contracts": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.8.0.tgz",
-      "integrity": "sha512-AGuwhRRL+NaKx73WKRNzeCxOCOCxpaqF+kp8TJ89QzAipSwZy/NoflkWaL9bywXFRhIzXt8j38sfF7KBKCPWLw==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.8.2.tgz",
+      "integrity": "sha512-kEUOgPQszC0fSYWpbh2kT94ltOJwj1qfT2DWo+zVttmGmf97JZ99LspePNaeeaLhCImaHVeBbjaQFZQn7+Zc5g==",
       "dev": true
     },
     "node_modules/@sinclair/typebox": {
@@ -6893,9 +6893,9 @@
       }
     },
     "@openzeppelin/contracts": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.8.0.tgz",
-      "integrity": "sha512-AGuwhRRL+NaKx73WKRNzeCxOCOCxpaqF+kp8TJ89QzAipSwZy/NoflkWaL9bywXFRhIzXt8j38sfF7KBKCPWLw==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.8.2.tgz",
+      "integrity": "sha512-kEUOgPQszC0fSYWpbh2kT94ltOJwj1qfT2DWo+zVttmGmf97JZ99LspePNaeeaLhCImaHVeBbjaQFZQn7+Zc5g==",
       "dev": true
     },
     "@sinclair/typebox": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "klaw": "^4.1.0"
   },
   "devDependencies": {
-    "@openzeppelin/contracts": "4.8.0",
+    "@openzeppelin/contracts": "^4.8.2",
     "@types/diff-match-patch": "^1.0.32",
     "@types/jest": "^29.4.0",
     "@types/klaw": "^3.0.3",

--- a/src/ts/parserEtherscan.ts
+++ b/src/ts/parserEtherscan.ts
@@ -176,8 +176,8 @@ export class EtherscanParser {
             // and characters after import up to ;
             // replace all in file and match across multiple lines
             const removedImports = removedPragmaSolidity.replace(
-                /(\s)(import.*;)/gm,
-                '$1/* $2 */'
+                /^\s*?(import.*?;)/gms,
+                '/* $1 */'
             )
             // Rename SPDX-License-Identifier to SPDX--License-Identifier so the merged file will compile
             const removedSPDX = removedImports.replace(/SPDX-/, 'SPDX--')


### PR DESCRIPTION
The previous pattern did not work for multiline specific imports. For example:
```solidity
import {
    ItemOne,
    ItemTwo,
    ItemThree
} from "./path/to/Contract.sol";
```

One contract that has many of these types of import statements is on Ethereum Mainnet, address: `0x00000000000001ad428e4906aE43D8F9852d0dD6`

The changes made should still work for the existing import statements.