### PR TITLE
feat: add options to hide function arguments and return types

### DIFF
--- a/lib/converterClass2Dot.d.ts
+++ b/lib/converterClass2Dot.d.ts
@@ -4,6 +4,8 @@ export interface ClassOptions {
     hideContracts?: boolean;
     hideVariables?: boolean;
     hideFunctions?: boolean;
+    hideArguments?: boolean;
+    hideReturns?: boolean;
     hideModifiers?: boolean;
     hideEvents?: boolean;
     hideStructs?: boolean;

--- a/lib/converterClass2Dot.js
+++ b/lib/converterClass2Dot.js
@@ -176,9 +176,9 @@ const dotOperators = (umlClass, vizGroup, operators, options) => {
             dotString += dotOperatorStereotype(umlClass, operator.stereotype);
         }
         dotString += operator.name;
-        dotString += dotParameters(operator.parameters);
-        if (operator.returnParameters?.length > 0) {
-            dotString += ': ' + dotParameters(operator.returnParameters, true);
+        dotString += dotParameters(operator.parameters, false, options.hideArguments);
+        if (operator.returnParameters?.length > 0 && !options.hideReturns) {
+            dotString += ': ' + dotParameters(operator.returnParameters, true, options.hideArguments);
         }
         if (options.hideModifiers === false && operator.modifiers?.length > 0) {
             dotString += ` \\<\\<${operator.modifiers.join(', ')}\\>\\>`;
@@ -214,7 +214,12 @@ const dotOperatorStereotype = (umlClass, operatorStereotype) => {
     }
     return dotString + ' ';
 };
-const dotParameters = (parameters, returnParams = false) => {
+const dotParameters = (parameters, returnParams = false, hideArguments = false) => {
+    // If hiding arguments, just return empty parentheses for input parameters
+    // but still show return types
+    if (hideArguments && !returnParams) {
+        return '()';
+    }
     if (parameters.length == 1 && !parameters[0].name) {
         if (returnParams) {
             return parameters[0].type;

--- a/lib/sol2uml.js
+++ b/lib/sol2uml.js
@@ -61,6 +61,8 @@ program
     .option('-c, --clusterFolders', 'cluster contracts into source folders', false)
     .option('-hv, --hideVariables', 'hide variables from contracts, interfaces, structs and enums', false)
     .option('-hf, --hideFunctions', 'hide functions from contracts, interfaces and libraries', false)
+    .option('-hg, --hideArguments', 'hide function arguments from contracts, interfaces and libraries', false)
+    .option('-hr, --hideReturns', 'hide function return types from contracts, interfaces and libraries', false)
     .option('-hp, --hidePrivates', 'hide private and internal attributes and operators', false)
     .option('-hm, --hideModifiers', 'hide modifier functions from contracts', false)
     .option('-ht, --hideEvents', 'hide events from contracts, interfaces and libraries', false)

--- a/src/ts/converterClass2Dot.ts
+++ b/src/ts/converterClass2Dot.ts
@@ -15,6 +15,8 @@ export interface ClassOptions {
     hideContracts?: boolean
     hideVariables?: boolean
     hideFunctions?: boolean
+    hideArguments?: boolean
+    hideReturns?: boolean
     hideModifiers?: boolean
     hideEvents?: boolean
     hideStructs?: boolean
@@ -255,6 +257,8 @@ const dotOperators = (
         hideModifiers?: boolean
         hideEvents?: boolean
         hideSourceContract?: boolean
+        hideArguments?: boolean
+        hideReturns?: boolean
     },
 ): string => {
     // Skip if there are no operators
@@ -288,10 +292,10 @@ const dotOperators = (
 
         dotString += operator.name
 
-        dotString += dotParameters(operator.parameters)
+        dotString += dotParameters(operator.parameters, false, options.hideArguments)
 
-        if (operator.returnParameters?.length > 0) {
-            dotString += ': ' + dotParameters(operator.returnParameters, true)
+        if (operator.returnParameters?.length > 0 && !options.hideReturns) {
+            dotString += ': ' + dotParameters(operator.returnParameters, true, options.hideArguments)
         }
 
         if (options.hideModifiers === false && operator.modifiers?.length > 0) {
@@ -341,7 +345,14 @@ const dotOperatorStereotype = (
 const dotParameters = (
     parameters: Parameter[],
     returnParams: boolean = false,
+    hideArguments: boolean = false,
 ): string => {
+    // If hiding arguments, just return empty parentheses for input parameters
+    // but still show return types
+    if (hideArguments && !returnParams) {
+        return '()'
+    }
+
     if (parameters.length == 1 && !parameters[0].name) {
         if (returnParams) {
             return parameters[0].type

--- a/src/ts/sol2uml.ts
+++ b/src/ts/sol2uml.ts
@@ -145,6 +145,16 @@ program
         false,
     )
     .option(
+        '-hg, --hideArguments',
+        'hide function arguments from contracts, interfaces and libraries',
+        false,
+    )
+    .option(
+        '-hr, --hideReturns',
+        'hide function return types from contracts, interfaces and libraries',
+        false,
+    )
+    .option(
         '-hp, --hidePrivates',
         'hide private and internal attributes and operators',
         false,


### PR DESCRIPTION
Add two new command-line options to simplify function signatures in UML class diagrams:
- `--hideArguments` (-hg): Hide function parameters while keeping function names and return types
- `--hideReturns` (-hr): Hide function return types while keeping function names and parameters

These options help reduce visual clutter in diagrams when dealing with functions that have complex or lengthy parameter/return type lists. Both options can be used independently or together for maximum simplification.

Changes:
- Add hideArguments and hideReturns to ClassOptions interface
- Add -hg/--hideArguments and -hr/--hideReturns CLI options
- Modify dotParameters function to return empty parentheses when hideArguments is enabled
- Modify dotOperators function to skip return type display when hideReturns is enabled